### PR TITLE
Fixed: on changing the segment the cancellation selection not reseting issue (#113)

### DIFF
--- a/src/views/Order.vue
+++ b/src/views/Order.vue
@@ -440,6 +440,7 @@ export default defineComponent({
         this.selectedItemsByFacility = {}
         this.order.shipGroup.items.map((item: any) => {
           item.selectedFacilityId = ""
+          item.isItemCancelled = false
         })
       }
     },


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

#113

### Short Description and Why It's Useful
<!-- Describe in a few words what is this Pull Request changing and why it's useful -->
Resetting the cancellation selection on items on changing the segment.

### Screenshots of Visual Changes before/after (If There Are Any)
<!-- If you made any changes in the UI layer, please provide before/after screenshots -->


### Contribution and Currently Important Rules Acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/hotwax/reroute-fulfilment#contribution-guideline)